### PR TITLE
Using --dump-runtime-variables to configure

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -1,8 +1,24 @@
 use alienfile;
 
 use Config;
-requires 'ExtUtils::CBuilder';
+use Data::Dumper;
+use File::Basename qw(dirname);
+
+# Also need Alien::SWIProlog::Util
+use lib dirname(__FILE__) . "/lib";
+
 requires 'Path::Tiny';
+requires 'File::Which';
+
+# For system probe
+requires 'List::Util', '1.33';
+requires 'ExtUtils::CBuilder';
+
+my @SWIPL_BIN_NAMES = (
+	( exists $ENV{PL} ? $ENV{PL} : () ),
+	( $^O =~ /Win32/ ? 'plcon' : () ),
+	qw(swipl swi-prolog pl),
+);
 
 my $test_program = <<EOF;
 /* checking for conflicting symbol */
@@ -15,37 +31,82 @@ int main(int argc, char *argv[]) {
 }
 EOF
 
-plugin 'PkgConfig' => 'swipl';
-
-meta->around_hook( probe => sub {
-	my $orig = shift;
+my $PLVARS;
+my $PL;
+probe sub {
 	my $build = shift;
-	my $return = $orig->($build, @_);
+	eval 'require Alien::SWIProlog::Util';
 
-	if( $return eq 'system' ) {
-		# run gather_system now
-		#$build->_call_hook( 'gather_system', $build );
-		$build->meta->{hook}{gather_system}[0]->execute( $build );
+	local $Data::Dumper::Terse = 1;
+	local $Data::Dumper::Sortkeys = 1;
+
+	for $PL (@SWIPL_BIN_NAMES) {
+		my $PL_path = File::Which::which($PL) or next;
+		$build->log("Trying SWI-Prolog binary $PL ($PL_path)");
+		$PLVARS = Alien::SWIProlog::Util::get_plvars($PL)
+			and last;
+	};
+
+	# when not found
+	return 'share' unless $PLVARS;
+
+	$build->log( Dumper($PLVARS) );
+
+	my %threads_support = (
+		swipl_threads => $PLVARS->{PLTHREADS} eq 'yes',
+		perl_usethreads => defined($Config::Config{usethreads}),
+		perl_useithreads => defined($Config::Config{useithreads}),
+	);
+
+	my $all_threads = List::Util::all(
+		sub { $threads_support{$_} },
+		keys %threads_support );
+	my $all_nonthreads = List::Util::all(
+		sub { ! $threads_support{$_} },
+		keys %threads_support );
+
+	unless( $all_threads || $all_nonthreads ) {
+		$build->log(
+			"Threading models of SWI-Prolog and Perl do not match: "
+			. Dumper(\%threads_support)
+		);
+		return 'share';
+	}
+
+	my $prop = Alien::SWIProlog::Util::plvars_to_props($PL, $PLVARS);
+
+	eval {
 		require ExtUtils::CBuilder;
 		my $b = ExtUtils::CBuilder->new();
 		my $src = Path::Tiny->tempfile( SUFFIX => '.c' );
 		$src->spew_utf8($test_program);
+		$build->log('Compiling/linking test program');
 		my $obj = $b->compile(
 			source => "$src",
-			extra_compiler_flags => $build->runtime_prop->{cflags},
+			extra_compiler_flags => $prop->{cflags},
 		);
 		my $exe = $b->link_executable(
 			objects => $obj,
-			extra_linker_flags   => $build->runtime_prop->{libs},
+			extra_linker_flags   => $prop->{libs},
 		);
-	}
+		$build->log('Compiling/linking successful');
+		1;
+	} and return 'system';
 
-	return $return;
-});
+	$build->log('Compiling/linking unsuccessful');
+	return 'share';
+};
+
+sys {
+	gather sub {
+		my ($build) = @_;
+		eval 'require Alien::SWIProlog::Util';
+		my $prop = Alien::SWIProlog::Util::plvars_to_props($PL, $PLVARS);
+		$build->runtime_prop->{$_} = $prop->{$_} for keys %$prop;
+	};
+};
 
 share {
-	requires 'File::Which';
-
 	my $release_type = 'stable';
 	die "Release type must be either 'stable' or 'devel'"
 		unless $release_type =~ /^(stable|devel)$/;
@@ -83,11 +144,12 @@ share {
 			@{ meta->prop->{plugin_build_cmake}->{args} },
 			@other_cmake_args,
 			$threads,
-			qw(
-				-DSWIPL_PACKAGES_X=OFF
-				-DINSTALL_DOCUMENTATION=OFF
-			),
-			'%{.install.extract}'
+			# no X11 library
+			qw(-DSWIPL_PACKAGES_X=OFF),
+			# do not build docs
+			qw(-DINSTALL_DOCUMENTATION=OFF),
+			# install shared library under lib, not lib/$arch
+			qw(-DSWIPL_INSTALL_IN_LIB=ON),
 		],
 		sub {
 			if( $is_msys2_mingw ) {
@@ -99,4 +161,26 @@ share {
 		'%{make}',
 		'%{make} install',
 	];
+
+	gather sub {
+		my ($build) = @_;
+		my $prefix = Path::Tiny::path($build->runtime_prop->{prefix});
+
+		my @home_parts = qw(lib swipl);
+		my $home_path = $prefix->child(@home_parts);
+		my $inc_path = $home_path->child(qw(include));
+		my @lib_paths = $prefix->child(qw(lib));
+		push @lib_paths, map { $prefix->child($_) }
+			grep { $_->is_dir && $_ !~ /swiplserver/ }
+			Path::Tiny::path(@home_parts, 'lib')->children;
+		my @ldlibs = "-lswipl";
+
+		my $cflags = "-I$inc_path";
+		my $libs = join " ",
+			( map  "-L$_", @lib_paths  ) ,
+			@ldlibs;
+
+		$build->runtime_prop->{cflags}  = $cflags;
+		$build->runtime_prop->{libs}    = $libs;
+	};
 };

--- a/alienfile
+++ b/alienfile
@@ -181,6 +181,7 @@ share {
 			qw(-DINSTALL_DOCUMENTATION=OFF),
 			# install shared library under lib, not lib/$arch
 			qw(-DSWIPL_INSTALL_IN_LIB=ON),
+			'.',
 		],
 		sub {
 			if( $is_msys2_mingw ) {

--- a/alienfile
+++ b/alienfile
@@ -17,7 +17,8 @@ requires 'ExtUtils::CBuilder';
 my @SWIPL_BIN_NAMES = (
 	( exists $ENV{PL} ? $ENV{PL} : () ),
 	( $^O =~ /Win32/ ? 'plcon' : () ),
-	qw(swipl swi-prolog pl),
+	qw(swipl swi-prolog),
+	( $^O !~ /darwin/ ? 'pl' : () ),
 );
 
 my $test_program = <<EOF;

--- a/alienfile
+++ b/alienfile
@@ -44,12 +44,12 @@ probe sub {
 	for $PL (@SWIPL_BIN_NAMES) {
 		my $PL_path = File::Which::which($PL) or next;
 		$build->log("Trying SWI-Prolog binary $PL ($PL_path)");
-		$PLVARS = Alien::SWIProlog::Util::get_plvars($PL)
-			and last;
+		$PLVARS = Alien::SWIProlog::Util::get_plvars($PL);
+		keys %$PLVARS and last;
 	};
 
 	# when not found
-	return 'share' unless $PLVARS;
+	return 'share' unless keys %$PLVARS;
 
 	$build->log( Dumper($PLVARS) );
 

--- a/alienfile
+++ b/alienfile
@@ -1,6 +1,8 @@
 use alienfile;
 
+use Env qw(@CMAKE_INCLUDE_PATH @CMAKE_LIBRARY_PATH);
 use Config;
+use DynaLoader ();
 use Data::Dumper;
 use File::Basename qw(dirname);
 
@@ -130,7 +132,7 @@ share {
 	my $threads = $Config{useithreads} ? '-DMULTI_THREADED=ON' : '-DMULTI_THREADED=OFF';
 
 	my @other_cmake_args = ();
-	my $is_msys2_mingw = exists $ENV{MSYSTEM} && $ENV{MSYSTEM} =~ /^mingw(32|64)$/i;
+	my $is_msys2_mingw = $^O eq 'MSWin32' && exists $ENV{MSYSTEM} && $ENV{MSYSTEM} =~ /^mingw(32|64)$/i;
 	if( $is_msys2_mingw && File::Which::which('cygpath') ) {
 		# Running under MSYS2
 		chomp( my $MINGW_ROOT = `cygpath -m /$ENV{MSYSTEM}` );
@@ -138,6 +140,34 @@ share {
 
 		# current build not set up to link with libarchive correctly
 		push @other_cmake_args, '-DSWIPL_PACKAGES_ARCHIVE=OFF';
+	}
+	my $is_strawberry = $^O eq 'MSWin32' && $Config{myuname} =~ /^Win32 strawberry-perl/;
+	if( $is_strawberry ) {
+		# This helps to find the paths under Strawberry Perl.
+		my ($zlib_found) = DynaLoader::dl_findfile('-lzlib');
+		if( $zlib_found ) {
+			my $zlib_file = Path::Tiny::path($zlib_found);
+
+			my $c_lib_dir = $zlib_file->parent;
+			my $c_dir = $c_lib_dir->parent;
+			my $c_inc_dir = $c_dir->child('include');
+
+			my $arch = 'x86_64-w64-mingw32';
+			my $arch_lib_dir = $c_dir->child($arch, 'lib' );
+			my $arch_inc_dir = $c_dir->child($arch, 'include' );
+
+			push @CMAKE_LIBRARY_PATH, "$c_lib_dir", "$arch_lib_dir";
+			push @CMAKE_INCLUDE_PATH, "$c_inc_dir", "$arch_inc_dir";
+
+			push @other_cmake_args, "-DMINGW_ROOT=$c_dir";
+
+			# no libgmp in Strawberry Perl
+			push @other_cmake_args, '-DUSE_GMP=OFF';
+
+			# not able to generate certs for tests due to missing
+			# openssl.cnf
+			push @other_cmake_args, '-DSKIP_SSL_TESTS=ON';
+		}
 	}
 
 	build [
@@ -167,16 +197,25 @@ share {
 		my ($build) = @_;
 		my $prefix = Path::Tiny::path($build->runtime_prop->{prefix});
 
+		my $is_windows = $^O eq 'MSWin32';
+
 		my @home_parts = qw(lib swipl);
-		my $home_path = $prefix->child(@home_parts);
+		my $home_path =
+			$is_windows
+			? $prefix
+			: $prefix->child(@home_parts);
+
 		my $inc_path = $home_path->child(qw(include));
+
 		my @lib_paths = $prefix->child(qw(lib));
+		push @lib_paths, $prefix->child(qw(bin)) if $is_windows;
 		my $lib_home_path = Path::Tiny::path(@home_parts, 'lib');
 		if( -d $lib_home_path ) {
 			push @lib_paths, map { $prefix->child($_) }
 				grep { $_->is_dir && $_ !~ /swiplserver/ }
 				$lib_home_path->children;
 		}
+
 		my @ldlibs = "-lswipl";
 
 		my $cflags = "-I$inc_path";
@@ -187,6 +226,7 @@ share {
 		my @rpaths = map { "" . $_->relative($prefix) }
 			@lib_paths;
 
+		$build->runtime_prop->{home}    = "$home_path";
 		$build->runtime_prop->{cflags}  = $cflags;
 		$build->runtime_prop->{libs}    = $libs;
 		$build->runtime_prop->{rpath}   = \@rpaths;

--- a/alienfile
+++ b/alienfile
@@ -171,9 +171,12 @@ share {
 		my $home_path = $prefix->child(@home_parts);
 		my $inc_path = $home_path->child(qw(include));
 		my @lib_paths = $prefix->child(qw(lib));
-		push @lib_paths, map { $prefix->child($_) }
-			grep { $_->is_dir && $_ !~ /swiplserver/ }
-			Path::Tiny::path(@home_parts, 'lib')->children;
+		my $lib_home_path = Path::Tiny::path(@home_parts, 'lib');
+		if( -d $lib_home_path ) {
+			push @lib_paths, map { $prefix->child($_) }
+				grep { $_->is_dir && $_ !~ /swiplserver/ }
+				$lib_home_path->children;
+		}
 		my @ldlibs = "-lswipl";
 
 		my $cflags = "-I$inc_path";

--- a/alienfile
+++ b/alienfile
@@ -180,7 +180,11 @@ share {
 			( map  "-L$_", @lib_paths  ) ,
 			@ldlibs;
 
+		my @rpaths = map { "" . $_->relative($prefix) }
+			@lib_paths;
+
 		$build->runtime_prop->{cflags}  = $cflags;
 		$build->runtime_prop->{libs}    = $libs;
+		$build->runtime_prop->{rpath}   = \@rpaths;
 	};
 };

--- a/alienfile
+++ b/alienfile
@@ -36,6 +36,7 @@ EOF
 
 my $PLVARS;
 my $PL;
+my $PL_path;
 probe sub {
 	my $build = shift;
 	eval 'require Alien::SWIProlog::Util';
@@ -44,7 +45,7 @@ probe sub {
 	local $Data::Dumper::Sortkeys = 1;
 
 	for $PL (@SWIPL_BIN_NAMES) {
-		my $PL_path = File::Which::which($PL) or next;
+		$PL_path = File::Which::which($PL) or next;
 		$build->log("Trying SWI-Prolog binary $PL ($PL_path)");
 		$PLVARS = Alien::SWIProlog::Util::get_plvars($PL);
 		keys %$PLVARS and last;
@@ -76,7 +77,7 @@ probe sub {
 		return 'share';
 	}
 
-	my $prop = Alien::SWIProlog::Util::plvars_to_props($PL, $PLVARS);
+	my $prop = Alien::SWIProlog::Util::plvars_to_props($PL_path, $PLVARS);
 
 	eval {
 		require ExtUtils::CBuilder;
@@ -104,7 +105,7 @@ sys {
 	gather sub {
 		my ($build) = @_;
 		eval 'require Alien::SWIProlog::Util';
-		my $prop = Alien::SWIProlog::Util::plvars_to_props($PL, $PLVARS);
+		my $prop = Alien::SWIProlog::Util::plvars_to_props($PL_path, $PLVARS);
 		$build->runtime_prop->{$_} = $prop->{$_} for keys %$prop;
 	};
 };
@@ -206,6 +207,8 @@ share {
 			? $prefix
 			: $prefix->child(@home_parts);
 
+		my $swipl_bin = $prefix->child(qw(bin swipl));
+
 		my $inc_path = $home_path->child(qw(include));
 
 		my @lib_paths = $prefix->child(qw(lib));
@@ -227,6 +230,7 @@ share {
 		my @rpaths = map { "" . $_->relative($prefix) }
 			@lib_paths;
 
+		$build->runtime_prop->{'swipl-bin'} = "$swipl_bin";
 		$build->runtime_prop->{home}    = "$home_path";
 		$build->runtime_prop->{cflags}  = $cflags;
 		$build->runtime_prop->{libs}    = $libs;

--- a/dist.ini
+++ b/dist.ini
@@ -9,3 +9,7 @@ version = 0.001
 [@Author::ZMUGHAL]
 
 [AlienBuild]
+
+[Prereqs / ConfigureRequires]
+; needed for Alien::SWIProlog::Util
+Capture::Tiny = 0

--- a/lib/Alien/SWIProlog.pm
+++ b/lib/Alien/SWIProlog.pm
@@ -4,8 +4,11 @@ package Alien::SWIProlog;
 use strict;
 use warnings;
 
-use parent qw(Alien::Base);
+use base qw(Alien::Base);
+use Role::Tiny::With qw( with );
 use Alien::SWIProlog::Util;
+
+with 'Alien::Role::Dino';
 
 1;
 =head1 SEE ALSO

--- a/lib/Alien/SWIProlog.pm
+++ b/lib/Alien/SWIProlog.pm
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 
 use parent qw(Alien::Base);
+use Alien::SWIProlog::Util;
 
 1;
 =head1 SEE ALSO

--- a/lib/Alien/SWIProlog/Util.pm
+++ b/lib/Alien/SWIProlog/Util.pm
@@ -22,11 +22,11 @@ sub get_plvars {
 sub plvars_to_props {
 	my ($pl, $plvars) = @_;
 	return +{
+		'swipl-bin' => $pl,
+		home => $plvars->{PLBASE},
 		cflags => "-I$plvars->{PLBASE}/include",
 		libs => "-L$plvars->{PLLIBDIR} $plvars->{PLLIB}",
-		exe => $pl,
-		rpath => $plvars->{PLLIBDIR},
-		_PL => $pl,
+		rpath => [ $plvars->{PLLIBDIR} ],
 		_PLVARS => $plvars,
 	}
 }

--- a/lib/Alien/SWIProlog/Util.pm
+++ b/lib/Alien/SWIProlog/Util.pm
@@ -1,0 +1,39 @@
+package Alien::SWIProlog::Util;
+# ABSTRACT: Utilities for SWI-Prolog configuration
+
+use Capture::Tiny qw(capture_stdout);
+
+use constant SWIPL_ARGS => qw(
+	--dump-runtime-variables
+	-dump-runtime-variables
+);
+
+sub get_plvars {
+	my ($pl_bin) = @_;
+	for my $arg ( SWIPL_ARGS() ) {
+		my ($out, $exit) = capture_stdout {
+			system( $pl_bin, $arg );
+		};
+		my $plvars = parse_plvars($out);
+		return $plvars;
+	}
+}
+
+sub plvars_to_props {
+	my ($pl, $plvars) = @_;
+	return +{
+		cflags => "-I$plvars->{PLBASE}/include",
+		libs => "-L$plvars->{PLLIBDIR} $plvars->{PLLIB}",
+		exe => $pl,
+		rpath => $plvars->{PLLIBDIR},
+		_PL => $pl,
+		_PLVARS => $plvars,
+	}
+}
+
+sub parse_plvars {
+	my ($pl_dump_output) = @_;
+	return +{ $pl_dump_output =~ /^(PL.*?)="(.*)";$/mg };
+}
+
+1;

--- a/t/basic.t
+++ b/t/basic.t
@@ -6,18 +6,25 @@ use Alien::SWIProlog;
 use DynaLoader;
 use Path::Tiny;
 
-my $distdir = path(Alien::SWIProlog->runtime_prop->{distdir});
-my $swi_home_dir = $distdir->child( qw(lib swipl) );
-my ($swi_lib_dir) = grep { $_->is_dir && $_ !~ /swiplserver/ }
-	$swi_home_dir->child('lib')->children();
-
-$ENV{SWI_HOME_DIR} = $swi_home_dir;
-unshift @DynaLoader::dl_library_path, $swi_lib_dir;
-
-DynaLoader::dl_load_file((DynaLoader::dl_findfile('-lswipl'))[0]);
-
 alien_diag 'Alien::SWIProlog';
 alien_ok 'Alien::SWIProlog';
+
+my $distdir = path( Alien::SWIProlog->runtime_prop->{distdir} );
+my $PL = $distdir->child(qw(bin swipl));
+my $swi_home_dir = $distdir->child( qw(lib swipl) );
+my @swi_lib_dirs = $distdir->child(qw(lib));
+push @swi_lib_dirs, grep { $_->is_dir && $_ !~ /swiplserver/ }
+        $swi_home_dir->child('lib')->children();
+
+$ENV{SWI_HOME_DIR} = $swi_home_dir;
+use Env qw(@LD_LIBRARY_PATH);
+unshift @LD_LIBRARY_PATH, @swi_lib_dirs;
+unshift @DynaLoader::dl_library_path, @swi_lib_dirs;
+my ($dlfile) = DynaLoader::dl_findfile('-lswipl');
+DynaLoader::dl_load_file($dlfile);
+
+require Alien::SWIProlog::Util;
+my $PLVARS = Alien::SWIProlog::Util::get_plvars($PL);
 
 my $xs = do { local $/; <DATA> };
 xs_ok { xs => $xs,  verbose => 1 }, with_subtest {

--- a/t/basic.t
+++ b/t/basic.t
@@ -54,10 +54,10 @@ __DATA__
 int
 init(const char *class)
 {
-	int PL_argc;
+	int PL_argc = 0;
 	char empty_arg[] = "";
 
-	char* PL_argv[1];
+	char** PL_argv[1];
 	PL_argv[PL_argc++] = empty_arg;
 
 	return PL_initialise(PL_argc, PL_argv);

--- a/t/basic.t
+++ b/t/basic.t
@@ -17,8 +17,10 @@ push @swi_lib_dirs, grep { $_->is_dir && $_ !~ /swiplserver/ }
         $swi_home_dir->child('lib')->children();
 
 $ENV{SWI_HOME_DIR} = $swi_home_dir;
-use Env qw(@LD_LIBRARY_PATH);
+use Env qw(@LD_LIBRARY_PATH @DYLD_FALLBACK_LIBRARY_PATH @PATH);
 unshift @LD_LIBRARY_PATH, @swi_lib_dirs;
+unshift @DYLD_FALLBACK_LIBRARY_PATH, @swi_lib_dirs;
+unshift @PATH, @swi_lib_dirs;
 unshift @DynaLoader::dl_library_path, @swi_lib_dirs;
 my ($dlfile) = DynaLoader::dl_findfile('-lswipl');
 DynaLoader::dl_load_file($dlfile);

--- a/t/basic.t
+++ b/t/basic.t
@@ -13,8 +13,11 @@ my $distdir = path( Alien::SWIProlog->runtime_prop->{distdir} );
 my $PL = $distdir->child(qw(bin swipl));
 my $swi_home_dir = $distdir->child( qw(lib swipl) );
 my @swi_lib_dirs = $distdir->child(qw(lib));
-push @swi_lib_dirs, grep { $_->is_dir && $_ !~ /swiplserver/ }
-        $swi_home_dir->child('lib')->children();
+my $swi_lib_home = $swi_home_dir->child('lib');
+if( -d $swi_lib_home ) {
+	push @swi_lib_dirs, grep { $_->is_dir && $_ !~ /swiplserver/ }
+		$swi_home_dir->child('lib')->children();
+}
 
 $ENV{SWI_HOME_DIR} = $swi_home_dir;
 use Env qw(@LD_LIBRARY_PATH @DYLD_FALLBACK_LIBRARY_PATH @PATH);
@@ -23,7 +26,12 @@ unshift @DYLD_FALLBACK_LIBRARY_PATH, @swi_lib_dirs;
 unshift @PATH, @swi_lib_dirs;
 unshift @DynaLoader::dl_library_path, @swi_lib_dirs;
 my ($dlfile) = DynaLoader::dl_findfile('-lswipl');
-DynaLoader::dl_load_file($dlfile);
+if( $dlfile ) {
+	note "dlfile: $dlfile";
+	DynaLoader::dl_load_file($dlfile);
+} else {
+	note "dlfile: not found";
+}
 
 require Alien::SWIProlog::Util;
 my $PLVARS = Alien::SWIProlog::Util::get_plvars($PL);


### PR DESCRIPTION
- Improve gather phase and library loading for tests
- Add more shared library search paths
- Use Alien::Role::Dino for rpath
- Do not use 'pl' on macOS
- PLVARS should contain vars
- Make sure that lib home path exists
- Improve MSWin32 support
- Point CMake at current directory
- Initialise PL_argc
